### PR TITLE
Add StudyRecordForm for manual input and StudySession model for stori…

### DIFF
--- a/app/forms.py
+++ b/app/forms.py
@@ -1,0 +1,28 @@
+from flask_wtf import FlaskForm
+from wtforms import StringField, TextAreaField, SelectField, DateField, TimeField, SubmitField
+from wtforms.validators import DataRequired
+
+class StudyRecordForm(FlaskForm):   # create a form class for study records
+    subject = SelectField('Subject', choices=[
+        ('Mathematics', 'Mathematics'),
+        ('Computer Science', 'Computer Science'),
+        ('Physics', 'Physics'),
+        ('Literature', 'Literature'),
+        ('History', 'History')
+    ], validators=[DataRequired()])
+
+    date = DateField('Date', format='%Y-%m-%d', validators=[DataRequired()])
+    start_time = TimeField('Start Time', format='%H:%M', validators=[DataRequired()])
+    end_time = TimeField('End Time', format='%H:%M', validators=[DataRequired()])
+    location = StringField('Location', validators=[DataRequired()])
+
+    efficiency = SelectField('Efficiency Rating', choices=[
+        ('5', '5 - Excellent'),
+        ('4', '4 - Good'),
+        ('3', '3 - Average'),
+        ('2', '2 - Below Average'),
+        ('1', '1 - Poor')
+    ], validators=[DataRequired()])
+
+    notes = TextAreaField('Notes')
+    submit = SubmitField('Save Study Session')

--- a/app/models.py
+++ b/app/models.py
@@ -1,0 +1,12 @@
+from . import db  # ✅ 从当前模块引入已初始化的 db
+
+class StudySession(db.Model):
+    id = db.Column(db.Integer, primary_key=True)
+    subject = db.Column(db.String(100), nullable=False)
+    date = db.Column(db.Date, nullable=False)
+    start_time = db.Column(db.Time, nullable=False)
+    end_time = db.Column(db.Time, nullable=False)
+    location = db.Column(db.String(100), nullable=False)
+    efficiency = db.Column(db.Integer, nullable=False)
+    notes = db.Column(db.Text, nullable=True)
+    interruptions = db.Column(db.Integer, nullable=False, default=0)


### PR DESCRIPTION
### Summary

This update introduces the form and model needed for manually entering and saving study session data.

- **`forms.py`**:
  - Created `StudyRecordForm` using Flask-WTF
  - Includes fields for subject, date, start/end time, location, efficiency rating, and notes
  - Enables users to manually enter study session data

- **`models.py`**:
  - Added `StudySession` SQLAlchemy model
  - Stores form data into the database with proper field definitions
  - Fields match the form inputs and also include `interruptions` count

These data will later be queried and rendered in the table section of `visualize.html`, supporting the core visualization functionality of the application.